### PR TITLE
another solution to undoing a bad merge

### DIFF
--- a/fixup.html
+++ b/fixup.html
@@ -856,16 +856,54 @@ hash ID (or the 7 character abbreviation).  Yes, if you know the
 "&#94;" or "~" shortcuts you may use those.</p>
 
 <p>Undoing the file modifications caused by the merge is about as
-simple as you might hope.  <code class="inline">git revert SHA</code>.
+simple as you might hope.  <code class="inline">git revert -m 1 SHA</code>.
+(Obviously replace "SHA" with the reference you want to revert;
+<code class="inline">-m 1</code> will revert changes from all but
+the first parent, which is almost always what you want.)
 Unfortunately, this is just the tip of the iceberg.  The problem is,
-what happens if you want to merge that branch later, perhaps months
-later long after you have exiled this problem from your memory, either
-to this branch or to some other branch this branch merged into.  Well,
-the problem is git has it tracked in history that a merge occurred, so
-it is not going to attempt to remerge what it has already merged.  The
-fact that it was later reverted is irrelevant.  You could revert the
-revert, but that supposes that you remember that you need to do
-so.</p>
+what happens months later, long after you have exiled this problem
+from your memory, when you try again to merge these branches (or any
+other branches they have been merged into)?  Because git has it
+tracked in history that a merge occurred, it is not going to attempt
+to remerge what it has already merged, and even worse, if you merge
+<em>from</em> the branch where you did the revert you will undo the
+changes on the branch where they were made.  (Imagine you revert a
+premature merge of a long-lived topic branch into master and later
+merge master into the topic branch to get other changes for testing.)
+</p>
+
+<p>One option is actually to do this reverse merge immediately,
+annihilating any changes before the bad merge, and then to "revert the
+revert" to restore them.  This leaves the changes removed from the
+branch you mistakenly merged to, but present on their original
+branch, and allows merges in either direction without loss.  This
+is the simplest option, and in many cases, can be the best.</p>
+
+<p>A disadvantage of this approach is that <code class="inline">git
+blame</code> output is not as useful (all the changes will be
+attributed to the revert of the revert) and <code class="inline">git
+bisect</code> is similarly impaired.  Another disadvantage is that
+you must merge all current changes in the target of the bad merge back
+into the source; if your development style is to keep branches clean,
+this may be undesirable, and if you rebase your branches (e.g. with
+<code class="inline">git pull --rebase</code>), it could cause
+complications unless you are careful to use <code class="inline">git
+rebase -p</code> to preserve merges.</p>
+
+<p>In the following example please replace $destination with the name
+of the branch that was the destination of the bad merge, $source
+with the name of the branch that was the source of the bad merge,
+and $sha with the SHA-1 hash ID of the bad merge itself.</p>
+
+<div class="prediv"><div class="befaftpre"><!-- --></div><pre><code>
+git checkout $destination
+git revert $sha
+# save the SHA-1 of the revert commit to un-revert it later
+revert=`git rev-parse HEAD`
+git checkout $source
+git merge $destination
+git revert $revert
+</code></pre><div class="befaftpre"><!-- --></div></div>
 
 <p>Another option is to abandon the branch you merged from, recreate
 it from the previous merge-base with the commits since then rebased or
@@ -877,10 +915,13 @@ remember to use the new branch.  Hopefully you have something like
 <a href="https://github.com/sitaramc/gitolite">gitolite</a> where you can close
 the old branch name.</p>
 
-<p>At this time, I will not walk you through the process of recreating
+<p>This approach has the advantage that the recreated donor branch
+will have cleaner history, but especially if there have been many
+commits (and especially merges) to the branch, it can be a lot of work.
+At this time, I will not walk you through the process of recreating
 the donor branch.  Given sufficient demand I can try to add that.
-However, if you look at howto/revert-a-faulty-merge.txt which is
-shipped as part of the git distribution, it will provide more words
+However, if you look at <a href="https://www.kernel.org/pub/software/scm/git/docs/howto/revert-a-faulty-merge.txt">howto/revert-a-faulty-merge.txt</a>
+(also shipped as part of the git distribution) it will provide more words
 than you can shake a stick at.</p>
 
 <p><a name="branch_overlay_merge" /></p><div name="crumbs"></div>


### PR DESCRIPTION
Hi Seth,

Ran into this problem today, and came up with another solution that worked well for us.
I wouldn't say it is a terribly clean one, but it is fairly simple.  I did try to discuss the
advantages and disadvantages of the two options fairly well.

These changes also correct the git command used to revert the merge,
which lacked the "-m 1" option needed to actually work.

There's also a real hyperlink to the howto/revert-a-faulty-merge.txt file.

@alex
